### PR TITLE
Remove Long Beach and Pasadena note

### DIFF
--- a/index.md
+++ b/index.md
@@ -82,7 +82,6 @@ layout: default
       {% endfor %}
     </tbody>
   </table>
-  <p class="font-sans-2xs">Note: This table includes Pasadena and Long Beach which are technically outside of LA County.</p>
   <p class="font-sans-2xs">Site last updated: <span class="font-mono-2xs">{{ site.time | date: "%x %r" }}</span> <span class="margin-x-1">|</span> <a class="usa-link" href="https://github.com/maya/la-coronavirus-cases">Contribute to this project on GitHub</a></p>
 </div>
 


### PR DESCRIPTION
[Long Beach](https://en.wikipedia.org/wiki/Long_Beach,_California)
>Incorporated in 1897, Long Beach lies in Southern California in the southeastern corner of Los Angeles County...

[Pasadena](https://en.wikipedia.org/wiki/Pasadena,_California)
>Pasadena is a city in Los Angeles County, California,...
